### PR TITLE
불필요한 디렉토리에 대한 linguist 설정 변경

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+exiftool/**/** linguist-vendored


### PR DESCRIPTION
## AS-IS

<img width="406" height="131" alt="Screenshot 2025-08-03 at 13 45 13" src="https://github.com/user-attachments/assets/5a99a373-4138-4b46-926d-ce4232f6e36b" />

## TO-BE

<img width="368" height="118" alt="Screenshot 2025-08-03 at 13 45 44" src="https://github.com/user-attachments/assets/7af6255f-5e7b-44cd-9202-cad5ea446e2a" />

- repository: https://github.com/heli-os/newboon-photo-sort
- 위 Repository에 적용되지 않는 것 처럼 보인다면, 캐시 타이밍 이슈이니 캐시 초기화 + 새로고침 몇번 해보시면 정상적으로 적용되어 있으실겁니다.

exiftool 디렉토리 하위는 전부 포함되어 있을 필요가 없어 보여서 제외처리 하였으니, 참고 부탁드립니다.